### PR TITLE
Enable both  accessories in the TextField

### DIFF
--- a/src/components/field/index.js
+++ b/src/components/field/index.js
@@ -525,8 +525,8 @@ export default class TextField extends PureComponent {
     );
   }
 
-  renderAccessory() {
-    let { renderAccessory } = this.props;
+renderAccessory(prop) {
+    let { [prop]: renderAccessory } = this.props;
 
     if ('function' !== typeof renderAccessory) {
       return null;


### PR DESCRIPTION
Enable both (Left and Right) accessories in a single component