### PR TITLE
fix: changed proptypes boolean to bool

### DIFF
--- a/src/components/field/index.js
+++ b/src/components/field/index.js
@@ -112,8 +112,8 @@ export default class TextField extends PureComponent {
 
     formatText: PropTypes.func,
 
-    renderLeftAccessory: PropTypes.oneOfType([PropTypes.func, PropTypes.boolean]),
-    renderRightAccessory: PropTypes.oneOfType([PropTypes.func, PropTypes.boolean]),
+    renderLeftAccessory: PropTypes.oneOfType([PropTypes.func, PropTypes.bool]),
+    renderRightAccessory: PropTypes.oneOfType([PropTypes.func, PropTypes.bool]),
 
     prefix: PropTypes.string,
     suffix: PropTypes.string,


### PR DESCRIPTION
I encountered this error when using the textfield. On investigating, I realised it was the PropType declaration that reference boolean instead of bool.
<img width="1050" alt="Screenshot 2021-12-27 at 20 22 10" src="https://user-images.githubusercontent.com/13138782/147501349-02e54599-05c8-484a-90a0-3cef8e5931e4.png">

Therefore, I changed the proptype from PropTypes.boolean to PropTypes.bool.
This error shows up as a warning and not an interrupting error.
